### PR TITLE
Specify default packet analyser in jar manifest

### DIFF
--- a/src/se/sics/jipv6/analyzer/TestSniff.java
+++ b/src/se/sics/jipv6/analyzer/TestSniff.java
@@ -138,6 +138,8 @@ public class TestSniff {
         TestSniff sniff = new TestSniff(analyzer);
         if(args.length > 1) {
             sniff.connect(args[1]);
+        } else {
+            sniff.connect("localhost");
         }
         BufferedReader input = new BufferedReader(new InputStreamReader(System.in));
         String line;


### PR DESCRIPTION
If no analyzer is specified on command line try analyzer class from jar manifest attribute "DefaultPacketAnalyzer".
